### PR TITLE
Reset the authentication_token when change the password success. 

### DIFF
--- a/app/services/devise_ios_rails/change_password_service.rb
+++ b/app/services/devise_ios_rails/change_password_service.rb
@@ -10,6 +10,7 @@ module DeviseIosRails
       return if current_user.nil?
       current_user.password = snake_case_params[:password]
       current_user.password_confirmation = snake_case_params[:password_confirmation]
+      current_user.authentication_token = nil
       current_user.save
       current_user
     end


### PR DESCRIPTION
Reset the authentication_token when change the password success. Otherwise the user can use the authentication_token to visit the resources anyway.
